### PR TITLE
feat(go/sdk): support adding a unary interceptor to client

### DIFF
--- a/go/sdk/event.go
+++ b/go/sdk/event.go
@@ -103,33 +103,35 @@ func newAPIStreamEventAPI(config APIStreamConfig) *APIStreamEventAPI {
 		getLiveApiServer(config),
 		grpc.WithTransportCredentials(transport),
 		grpc.WithUnaryInterceptor(func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-			mtd, hasCtx := metadata.FromOutgoingContext(ctx)
+			return config.UnaryInterceptor(ctx, method, req, reply, cc, func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+				mtd, hasCtx := metadata.FromOutgoingContext(ctx)
 
-			if !hasCtx {
-				mtd = metadata.New(map[string]string{})
-			}
-
-			// Only send the API key for relevant services
-			if strings.Contains(method, "Webhook") || strings.Contains(method, "History") {
-				if api.config.APIKey != "" {
-					mtd.Append("x-api-key", api.config.APIKey)
+				if !hasCtx {
+					mtd = metadata.New(map[string]string{})
 				}
-			} else {
-				if api.config.AccessToken != "" {
-					mtd.Append("authorization", "Bearer "+api.config.AccessToken)
+
+				// Only send the API key for relevant services
+				if strings.Contains(method, "Webhook") || strings.Contains(method, "History") {
+					if api.config.APIKey != "" {
+						mtd.Append("x-api-key", api.config.APIKey)
+					}
+				} else {
+					if api.config.AccessToken != "" {
+						mtd.Append("authorization", "Bearer "+api.config.AccessToken)
+					}
 				}
-			}
 
-			mtd.Append("ClientType", "golang")
-			if config.clientVersion != "" {
-				mtd.Append("Version", config.clientVersion)
-			}
+				mtd.Append("ClientType", "golang")
+				if config.clientVersion != "" {
+					mtd.Append("Version", config.clientVersion)
+				}
 
-			if len(config.FeatureOverrides) > 0 {
-				mtd.Append("x-feature-overrides", config.FeatureOverrides...)
-			}
+				if len(config.FeatureOverrides) > 0 {
+					mtd.Append("x-feature-overrides", config.FeatureOverrides...)
+				}
 
-			return invoker(metadata.NewOutgoingContext(ctx, mtd), method, req, reply, cc, opts...)
+				return invoker(metadata.NewOutgoingContext(ctx, mtd), method, req, reply, cc, opts...)
+			}, opts...)
 		}),
 	)
 

--- a/go/sdk/layout.go
+++ b/go/sdk/layout.go
@@ -83,27 +83,29 @@ func newAPIStreamLayoutAPI(config APIStreamConfig) *APIStreamLayoutAPI {
 		getLiveApiServer(config),
 		grpc.WithTransportCredentials(transport),
 		grpc.WithUnaryInterceptor(func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-			mtd, hasCtx := metadata.FromOutgoingContext(ctx)
+			return config.UnaryInterceptor(ctx, method, req, reply, cc, func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+				mtd, hasCtx := metadata.FromOutgoingContext(ctx)
 
-			if !hasCtx {
-				mtd = metadata.New(map[string]string{})
-			}
+				if !hasCtx {
+					mtd = metadata.New(map[string]string{})
+				}
 
-			// Only send the API key for relevant services
-			if api.config.AccessToken != "" {
-				mtd.Append("authorization", "Bearer "+api.config.AccessToken)
-			}
+				// Only send the API key for relevant services
+				if api.config.AccessToken != "" {
+					mtd.Append("authorization", "Bearer "+api.config.AccessToken)
+				}
 
-			mtd.Append("ClientType", "golang")
-			if config.clientVersion != "" {
-				mtd.Append("Version", config.clientVersion)
-			}
+				mtd.Append("ClientType", "golang")
+				if config.clientVersion != "" {
+					mtd.Append("Version", config.clientVersion)
+				}
 
-			if len(config.FeatureOverrides) > 0 {
-				mtd.Append("x-feature-overrides", config.FeatureOverrides...)
-			}
+				if len(config.FeatureOverrides) > 0 {
+					mtd.Append("x-feature-overrides", config.FeatureOverrides...)
+				}
 
-			return invoker(metadata.NewOutgoingContext(ctx, mtd), method, req, reply, cc, opts...)
+				return invoker(metadata.NewOutgoingContext(ctx, mtd), method, req, reply, cc, opts...)
+			}, opts...)
 		}),
 	)
 


### PR DESCRIPTION
Adds support for providing a unary interceptor which enables attaching tracing hooks.

This is done to prevent baking in datadog tracing support.

e.g
```go
package common

import (
	apistream "github.com/golightstream/api.stream-sdk/go/sdk"
	grpctrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc"
)

func NewApiStreamClient(token string) *apistream.APIStreamClient {
	return apistream.NewAPIStreamClient(apistream.APIStreamConfig{
		AccessToken:      token,
		UnaryInterceptor: grpctrace.UnaryClientInterceptor(grpctrace.WithServiceName("api.stream-sdk")),
	})
}
```

LSTREAM-567